### PR TITLE
GDPR support in Criteo adapter

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -9,6 +9,7 @@ var events = require('src/events');
 const ADAPTER_VERSION = 4;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
+const CRITEO_VENDOR_ID = 1; // /!\ TODO update the vendor Id to the real vendor id once registered in IAB vendor register
 const INTEGRATION_MODES = {
   'amp': 1,
 };
@@ -60,7 +61,7 @@ export const spec = {
     } else {
       const context = buildContext(bidRequests);
       url = buildCdbUrl(context);
-      data = buildCdbRequest(context, bidRequests);
+      data = buildCdbRequest(context, bidRequests, bidderRequest);
     }
 
     if (data) {
@@ -181,7 +182,7 @@ function buildCdbUrl(context) {
  * @param {BidRequest[]} bidRequests
  * @return {*}
  */
-function buildCdbRequest(context, bidRequests) {
+function buildCdbRequest(context, bidRequests, bidderRequest) {
   let networkId;
   const request = {
     publisher: {
@@ -209,6 +210,14 @@ function buildCdbRequest(context, bidRequests) {
   };
   if (networkId) {
     request.publisher.networkid = networkId;
+  }
+  if (bidderRequest && bidderRequest.gdprConsent) {
+    request.gdprConsent = {
+      gdprApplies: !!(bidderRequest.gdprConsent.gdprApplies),
+      consentData: bidderRequest.gdprConsent.consentString,
+      consentGiven: !!(bidderRequest.gdprConsent.vendorData && bidderRequest.gdprConsent.vendorData.vendorConsents &&
+        bidderRequest.gdprConsent.vendorData.vendorConsents[ CRITEO_VENDOR_ID.toString(10) ]),
+    };
   }
   return request;
 }

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -9,7 +9,7 @@ var events = require('src/events');
 const ADAPTER_VERSION = 4;
 const BIDDER_CODE = 'criteo';
 const CDB_ENDPOINT = '//bidder.criteo.com/cdb';
-const CRITEO_VENDOR_ID = 1; // /!\ TODO update the vendor Id to the real vendor id once registered in IAB vendor register
+const CRITEO_VENDOR_ID = 91;
 const INTEGRATION_MODES = {
   'amp': 1,
 };

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -48,7 +48,17 @@ describe('The Criteo bidding adapter', () => {
   });
 
   describe('buildRequests', () => {
-    const bidderRequest = { timeout: 3000 };
+    const bidderRequest = { timeout: 3000,
+      gdprConsent: {
+        gdprApplies: 1,
+        consentString: 'concentDataString',
+        vendorData: {
+          vendorConsents: {
+            '1': 1
+          },
+        },
+      },
+    };
 
     it('should properly build a zoneId request', () => {
       const bidRequests = [
@@ -73,9 +83,24 @@ describe('The Criteo bidding adapter', () => {
       expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
       expect(ortbRequest.slots[0].sizes[0]).to.equal('728x90');
       expect(ortbRequest.slots[0].zoneid).to.equal(123);
+      expect(ortbRequest.gdprConsent.consentData).to.equal('concentDataString');
+      expect(ortbRequest.gdprConsent.gdprApplies).to.equal(true);
+      expect(ortbRequest.gdprConsent.consentGiven).to.equal(true);
     });
 
     it('should properly build a networkId request', () => {
+      const bidderRequest = {
+        timeout: 3000,
+        gdprConsent: {
+          gdprApplies: 0,
+          consentString: undefined,
+          vendorData: {
+            vendorConsents: {
+              '1': 0
+            },
+          },
+        },
+      };
       const bidRequests = [
         {
           bidder: 'criteo',
@@ -99,9 +124,13 @@ describe('The Criteo bidding adapter', () => {
       expect(ortbRequest.slots[0].sizes).to.have.lengthOf(2);
       expect(ortbRequest.slots[0].sizes[0]).to.equal('300x250');
       expect(ortbRequest.slots[0].sizes[1]).to.equal('728x90');
+      expect(ortbRequest.gdprConsent.consentData).to.equal(undefined);
+      expect(ortbRequest.gdprConsent.gdprApplies).to.equal(false);
+      expect(ortbRequest.gdprConsent.consentGiven).to.equal(false);
     });
 
     it('should properly build a mixed request', () => {
+      const bidderRequest = { timeout: 3000 };
       const bidRequests = [
         {
           bidder: 'criteo',
@@ -138,6 +167,7 @@ describe('The Criteo bidding adapter', () => {
       expect(ortbRequest.slots[1].sizes).to.have.lengthOf(2);
       expect(ortbRequest.slots[1].sizes[0]).to.equal('300x250');
       expect(ortbRequest.slots[1].sizes[1]).to.equal('728x90');
+      expect(ortbRequest.gdprConsent).to.equal(undefined);
     });
   });
 


### PR DESCRIPTION
Before merging this pull request the CRITEO_VENDOR_ID has to be updated with the vendor id provided by IAB once Criteo will be added to the official vendor register. 
